### PR TITLE
update dependencies for poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,13 @@
 [tool.poetry]
 name = "requestlog"
-version = "0.1.0"
+version = "1.1.9"
 description = ""
 authors = ["Silvan Muehlemann <silvan.muehlemann@muehlemann-popp.ch>"]
+
+[tool.poetry.dependencies]
+django = ">=3.1"
+httplib2 = "*"
+psycopg2-binary = "*"
 
 [build-system]
 requires = [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     url="https://github.com/muehlemann-popp/requestlog",
     include_package_data=True,
     install_requires=[
-        'Django>=1.9',
+        'Django>=3.1',
         'httplib2',
         'psycopg2-binary',
     ],


### PR DESCRIPTION
place dependencies in pyproject.toml: django>=3.1, httplib2 and pep8 are required when installing withpoetry from other project